### PR TITLE
add quadrature rule

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -59,5 +59,6 @@ API
 .. autofunction:: flt.dlt
 .. autofunction:: flt.idlt
 .. autofunction:: flt.theta
+.. autofunction:: flt.quadrature
 .. autofunction:: flt.dct2dlt
 .. autofunction:: flt.dlt2dct

--- a/src/flt/__init__.py
+++ b/src/flt/__init__.py
@@ -8,6 +8,7 @@ __all__ = [
     "theta",
     "dct2dlt",
     "dlt2dct",
+    "quadrature",
 ]
 
 from flt.generic import (
@@ -16,4 +17,5 @@ from flt.generic import (
     theta,
     dct2dlt,
     dlt2dct,
+    quadrature,
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,7 +37,12 @@ def n(request):
 
 @pytest.fixture(params=[False, True])
 def closed(request):
-    return request.param
+    closed = request.param
+    if "xp" in request.fixturenames:
+        xp = request.getfixturevalue("xp")
+        if closed and xp.__name__ == "jax.numpy":
+            pytest.skip("no closed transform for jax")
+    return closed
 
 
 @pytest.fixture

--- a/tests/test_generic.py
+++ b/tests/test_generic.py
@@ -29,3 +29,12 @@ def test_idlt(xp, n, closed, rng):
 
     assert isinstance(out, type(a))
     np.testing.assert_allclose(out, f)
+
+
+def test_quadrature(xp, n, closed, rng):
+    a = xp.asarray(rng.uniform(0.0, 1.0, size=n))
+    w = flt.quadrature(n, closed, xp=xp)
+
+    coeff = flt.dlt(a, closed=closed)
+
+    np.testing.assert_allclose(w @ a, 2 * coeff[0])


### PR DESCRIPTION
Adds a function `quadrature()` that returns the weights of a quadrature rule that exactly integrates band-limited functions.